### PR TITLE
Compression/Universal hwaccel, audio options + bugfixes

### DIFF
--- a/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
+++ b/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
@@ -14,7 +14,15 @@ set size=Discord
 :: Resolution (tries to keep high res)
 set askfocus=true
 set focus=Framerate
-:: 
+:: Hardware acceleration
+:: Due to hardware encoders being not very good for this this script will still use libx264 for encoding.
+:: Available options (same as in ffmpeg -hwaccel):
+:: cpu (none)
+:: cuda (nvidia)
+:: d3d11va (everything)
+:: any other hwaccel
+set hwaccel=cpu
+::
 :: ADVANCED OPTIONS
 :: Be careful, only change them if you know what they do!
 ::
@@ -170,6 +178,12 @@ if %videobitrate% GEQ %target1% (
     set preset=veryslow
     set qpmin=0
 )
+:: hwaccel
+if %hwaccel% == cpu (
+    set hwaccel=
+) else (
+    set hwaccel=-hwaccel %hwaccel%
+)
 :: Preset force
 if %forcepreset% == no (
     echo Not forcing preset
@@ -185,7 +199,7 @@ if %focus% == Original (
 :: Echo settings
 echo %res%p%fps%, preset %preset%
 :: Run ffmpeg
-ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% %audioencoderoptions%-b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
+ffmpeg %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% %audioencoderoptions%-b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
 del ffmpeg2pass-0.log
 del ffmpeg2pass-0.log.mbtree
 pause

--- a/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
+++ b/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
@@ -19,7 +19,8 @@ set focus=Framerate
 :: Be careful, only change them if you know what they do!
 ::
 set audioencoder=aac
-set audiobitrateperc=10
+set audiobitratepercent=10
+set audioencoderoptions=
 set minaudiobitrate=128
 set maxaudiobitrate=256
 set mintotalbitrate=500
@@ -86,7 +87,7 @@ if %bitrate% LEQ %mintotalbitrate% (
     pause && exit
 )
 :: Audio bitrate
-set /A audiobitrate = %bitrate% / %audiobitrateperc%
+set /A audiobitrate = %bitrate% / %audiobitratepercent%
 if %audiobitrate% GEQ %maxaudiobitrate% (set audiobitrate=%maxaudiobitrate%)
 if %audiobitrate% LEQ %minaudiobitrate% (set audiobitrate=%minaudiobitrate%)
 :: Video bitrate
@@ -184,7 +185,7 @@ if %focus% == Original (
 :: Echo settings
 echo %res%p%fps%, preset %preset%
 :: Run ffmpeg
-ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% -b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
+ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% %audioencoderoptions%-b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
 del ffmpeg2pass-0.log
 del ffmpeg2pass-0.log.mbtree
 pause

--- a/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
+++ b/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
@@ -199,7 +199,7 @@ if %focus% == Original (
 :: Echo settings
 echo %res%p%fps%, preset %preset%
 :: Run ffmpeg
-ffmpeg %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% %audioencoderoptions%-b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
+ffmpeg %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%1 -vsync vfr -an -f null NUL && ffmpeg -y %hwaccel% -ss %starttime% -t %time% -i %1 %filters% -c:v %videoencoder% %encoderopts% -preset %preset% -b:v %videobitrate%k -x264-params qpmin=%qpmin% %twopasscommand%2 -c:a %audioencoder% %audioencoderoptions%-b:a %audiobitrate%k -vsync vfr -movflags +faststart "%~dpn1 (compressed).mp4"
 del ffmpeg2pass-0.log
 del ffmpeg2pass-0.log.mbtree
 pause

--- a/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
+++ b/7 ⠂ FFmpeg/⠂Compression bats/SendTo/experimental/Universal.bat
@@ -23,20 +23,20 @@ set audiobitrateperc=10
 set minaudiobitrate=128
 set maxaudiobitrate=256
 set mintotalbitrate=500
-set bitratetargetmult=1
+set bitratetargetpercent=100
 set videoencoder=libx264
 set forcepreset=no
 set twopasscommand=-pass 
 set encoderopts=-g 600
 set videofilters=,mpdecimate=max=6
 :: Bitrate targets
-set /A target1 = 5000 * %bitratetargetmult%
-set /A target2 = 3000 * %bitratetargetmult%
-set /A target3 = 2000 * %bitratetargetmult%
-set /A target4 = 1400 * %bitratetargetmult%
-set /A target5 = 1000 * %bitratetargetmult%
-set /A target6 = 700 * %bitratetargetmult%
-set /A target7 = 500 * %bitratetargetmult%
+set /A target1 = 50 * %bitratetargetpercent%
+set /A target2 = 30 * %bitratetargetpercent%
+set /A target3 = 20 * %bitratetargetpercent%
+set /A target4 = 14 * %bitratetargetpercent%
+set /A target5 = 10 * %bitratetargetpercent%
+set /A target6 = 7 * %bitratetargetpercent%
+set /A target7 = 5 * %bitratetargetpercent%
 :: Input check
 if %1check == check (
     echo ERROR: no input file
@@ -87,8 +87,8 @@ if %bitrate% LEQ %mintotalbitrate% (
 )
 :: Audio bitrate
 set /A audiobitrate = %bitrate% / %audiobitrateperc%
-if %audiobitrate% GEQ %maxaudiobitrate% (set audiobitrate=256)
-if %audiobitrate% LEQ %minaudiobitrate% (set audiobitrate=128)
+if %audiobitrate% GEQ %maxaudiobitrate% (set audiobitrate=%maxaudiobitrate%)
+if %audiobitrate% LEQ %minaudiobitrate% (set audiobitrate=%minaudiobitrate%)
 :: Video bitrate
 set /A videobitrate = %bitrate% - %audiobitrate%
 echo bitrate: %bitrate% (audio: %audiobitrate%, video: %videobitrate%)


### PR DESCRIPTION
New features:
- Hardware acceleration
- Audio encoder options
Fixed bugs:
- Bitrate multiplier not working (batch limit, didn't catch in testing), replaced with percentage
- Minimum and maximum audio bitrates being hardlocked to 128 and 256 respectively
- Overwrite file if it already exists (since 1st pass doesn't prompt yes/no as it's being piped to NUL)